### PR TITLE
Remember rotation changes and use interface for duplicate update method

### DIFF
--- a/src/main/java/org/terasology/adventureassets/traps/swingingblade/SwingingBladeClientSystem.java
+++ b/src/main/java/org/terasology/adventureassets/traps/swingingblade/SwingingBladeClientSystem.java
@@ -22,29 +22,18 @@ import org.terasology.engine.Time;
 import org.terasology.entitySystem.entity.EntityBuilder;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.entitySystem.entity.lifecycleEvents.BeforeRemoveComponent;
 import org.terasology.entitySystem.entity.lifecycleEvents.OnActivatedComponent;
-import org.terasology.entitySystem.entity.lifecycleEvents.OnAddedComponent;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
-import org.terasology.logic.health.BeforeDamagedEvent;
-import org.terasology.logic.health.BeforeDestroyEvent;
-import org.terasology.logic.health.DestroyEvent;
-import org.terasology.logic.health.DoDestroyEvent;
 import org.terasology.logic.location.Location;
-import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.registry.In;
-import org.terasology.world.BlockEntityRegistry;
 import org.terasology.world.block.BlockComponent;
-import org.terasology.world.block.entity.CreateBlockDropsEvent;
-import org.terasology.world.block.items.BlockItemComponent;
-import org.terasology.world.block.items.OnBlockItemPlaced;
 import org.terasology.world.block.items.OnBlockToItem;
 
 @RegisterSystem(RegisterMode.CLIENT)
@@ -58,6 +47,8 @@ public class SwingingBladeClientSystem extends BaseComponentSystem implements Up
     private AssetManager assetManager;
     @In
     private Time time;
+    @In
+    private SwingingBladeRotator swingingBladeRotator;
 
     /**
      * This method creates the mesh entity when the {@link SwingingBladeComponent} is activated. The rod and blade
@@ -68,6 +59,7 @@ public class SwingingBladeClientSystem extends BaseComponentSystem implements Up
      * {@link SwingingBladeServerSystem#onBlockToItem(OnBlockToItem, EntityRef, SwingingBladeComponent)} gets called.
      * So, the saved properties (amplitude, time-period, offset etc) are transferred after this, maintaining
      * only the childrenEntities list created here.
+     *
      * @param event
      * @param entity
      * @param swingingBladeComponent
@@ -87,19 +79,6 @@ public class SwingingBladeClientSystem extends BaseComponentSystem implements Up
 
     @Override
     public void update(float delta) {
-        for (EntityRef blade : entityManager.getEntitiesWith(SwingingBladeComponent.class, BlockComponent.class)) {
-            LocationComponent locationComponent = blade.getComponent(LocationComponent.class);
-            SwingingBladeComponent swingingBladeComponent = blade.getComponent(SwingingBladeComponent.class);
-            if (locationComponent != null && swingingBladeComponent.isSwinging) {
-                float t = time.getGameTime();
-                float timePeriod = swingingBladeComponent.timePeriod;
-                float pitch, A = swingingBladeComponent.amplitude, phi = swingingBladeComponent.offset;
-                float w = (float) (2 * Math.PI / timePeriod);
-                pitch = (float) (A * Math.cos(w * t + phi));
-                Quat4f rotation = locationComponent.getLocalRotation();
-                locationComponent.setLocalRotation(new Quat4f(rotation.getYaw(), pitch, rotation.getRoll()));
-                blade.saveComponent(locationComponent);
-            }
-        }
+        swingingBladeRotator.updateSwingingBladeRotation();
     }
 }

--- a/src/main/java/org/terasology/adventureassets/traps/swingingblade/SwingingBladeComponent.java
+++ b/src/main/java/org/terasology/adventureassets/traps/swingingblade/SwingingBladeComponent.java
@@ -18,6 +18,7 @@ package org.terasology.adventureassets.traps.swingingblade;
 import com.google.common.collect.Lists;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.math.geom.Quat4f;
 import org.terasology.world.block.ForceBlockActive;
 
 import java.util.List;
@@ -47,6 +48,11 @@ public class SwingingBladeComponent implements Component {
      * To set the blade in motion, or stop it
      */
     public boolean isSwinging = true;
+
+    /**
+     * Saved rotation extracted when block turns to item
+     */
+    public Quat4f rotation = new Quat4f(Quat4f.IDENTITY);
 
     public List<EntityRef> childrenEntities = Lists.newArrayList();
 }

--- a/src/main/java/org/terasology/adventureassets/traps/swingingblade/SwingingBladeRotator.java
+++ b/src/main/java/org/terasology/adventureassets/traps/swingingblade/SwingingBladeRotator.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.adventureassets.traps.swingingblade;
+
+public interface SwingingBladeRotator {
+    public void updateSwingingBladeRotation();
+}

--- a/src/main/java/org/terasology/adventureassets/traps/swingingblade/SwingingBladeServerSystem.java
+++ b/src/main/java/org/terasology/adventureassets/traps/swingingblade/SwingingBladeServerSystem.java
@@ -18,7 +18,6 @@ package org.terasology.adventureassets.traps.swingingblade;
 import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.assets.ResourceUrn;
 import org.terasology.assets.management.AssetManager;
 import org.terasology.engine.Time;
 import org.terasology.entitySystem.entity.EntityBuilder;
@@ -26,36 +25,27 @@ import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.lifecycleEvents.BeforeRemoveComponent;
 import org.terasology.entitySystem.entity.lifecycleEvents.OnActivatedComponent;
-import org.terasology.entitySystem.entity.lifecycleEvents.OnAddedComponent;
-import org.terasology.entitySystem.event.EventPriority;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
-import org.terasology.logic.characters.CharacterComponent;
 import org.terasology.logic.inventory.InventoryManager;
-import org.terasology.logic.inventory.events.InventorySlotChangedEvent;
 import org.terasology.logic.location.Location;
 import org.terasology.logic.location.LocationComponent;
-import org.terasology.logic.players.event.OnPlayerSpawnedEvent;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.registry.In;
-import org.terasology.structureTemplates.events.StructureSpawnerFromToolboxRequest;
-import org.terasology.structureTemplates.internal.components.StructureTemplateOriginComponent;
-import org.terasology.world.OnChangedBlock;
+import org.terasology.registry.Share;
 import org.terasology.world.block.BlockComponent;
-import org.terasology.world.block.BlockManager;
-import org.terasology.world.block.family.BlockFamily;
 import org.terasology.world.block.items.BlockItemComponent;
 import org.terasology.world.block.items.OnBlockItemPlaced;
 import org.terasology.world.block.items.OnBlockToItem;
 
+@Share(SwingingBladeRotator.class)
 @RegisterSystem(RegisterMode.AUTHORITY)
-public class SwingingBladeServerSystem extends BaseComponentSystem implements UpdateSubscriberSystem {
+public class SwingingBladeServerSystem extends BaseComponentSystem implements UpdateSubscriberSystem, SwingingBladeRotator {
 
     private static final Logger logger = LoggerFactory.getLogger(SwingingBladeServerSystem.class);
 
@@ -67,6 +57,8 @@ public class SwingingBladeServerSystem extends BaseComponentSystem implements Up
     private InventoryManager inventoryManager;
     @In
     private Time time;
+    @In
+    private SwingingBladeRotator swingingBladeRotator;
 
     @ReceiveEvent(components = {SwingingBladeComponent.class, LocationComponent.class, BlockComponent.class})
     public void onSwingingBladeDestroyed(BeforeRemoveComponent event, EntityRef entity,
@@ -80,13 +72,14 @@ public class SwingingBladeServerSystem extends BaseComponentSystem implements Up
      * filtering the {@link SwingingBladeComponent} gets executed.
      * So the placedBlock entity already has the right childrenEntities and only needs the trap properties to be
      * transferred.
+     *
      * @param event
      * @param itemEntity
      * @param swingingBladeComponent
      */
     @ReceiveEvent(components = {BlockItemComponent.class})
     public void onItemToBlock(OnBlockItemPlaced event, EntityRef itemEntity,
-                                  SwingingBladeComponent swingingBladeComponent) {
+                              SwingingBladeComponent swingingBladeComponent) {
         EntityRef entity = event.getPlacedBlock();
         SwingingBladeComponent component = entity.getComponent(SwingingBladeComponent.class);
         swingingBladeComponent.childrenEntities = component.childrenEntities;
@@ -99,6 +92,7 @@ public class SwingingBladeServerSystem extends BaseComponentSystem implements Up
     /**
      * This method transfers the stored properties in the block's {@link SwingingBladeComponent} to the new item created.
      * It also destroys the children entities, i.e. the rod, blade and the mesh.
+     *
      * @param event
      * @param blockEntity
      * @param swingingBladeComponent
@@ -121,13 +115,14 @@ public class SwingingBladeServerSystem extends BaseComponentSystem implements Up
      * {@link SwingingBladeServerSystem#onBlockToItem(OnBlockToItem, EntityRef, SwingingBladeComponent)} gets called.
      * So, the saved properties (amplitude, time-period, offset etc) are transferred after this, maintaining
      * only the childrenEntities list created here.
+     *
      * @param event
      * @param entity
      * @param swingingBladeComponent
      */
     @ReceiveEvent(components = {SwingingBladeComponent.class, BlockComponent.class})
     public void onSwingingBladeActivated(OnActivatedComponent event, EntityRef entity,
-                     SwingingBladeComponent swingingBladeComponent) {
+                                         SwingingBladeComponent swingingBladeComponent) {
         Prefab rodPrefab = assetManager.getAsset("AdventureAssets:rod", Prefab.class).get();
         EntityBuilder rodEntityBuilder = entityManager.newBuilder(rodPrefab);
         rodEntityBuilder.setOwner(entity);
@@ -149,6 +144,10 @@ public class SwingingBladeServerSystem extends BaseComponentSystem implements Up
 
     @Override
     public void update(float delta) {
+        swingingBladeRotator.updateSwingingBladeRotation();
+    }
+
+    public void updateSwingingBladeRotation() {
         for (EntityRef blade : entityManager.getEntitiesWith(SwingingBladeComponent.class, BlockComponent.class)) {
             LocationComponent locationComponent = blade.getComponent(LocationComponent.class);
             SwingingBladeComponent swingingBladeComponent = blade.getComponent(SwingingBladeComponent.class);

--- a/src/main/java/org/terasology/adventureassets/traps/swingingblade/SwingingBladeServerSystem.java
+++ b/src/main/java/org/terasology/adventureassets/traps/swingingblade/SwingingBladeServerSystem.java
@@ -68,14 +68,6 @@ public class SwingingBladeServerSystem extends BaseComponentSystem implements Up
     @In
     private Time time;
 
-    @ReceiveEvent(priority = EventPriority.PRIORITY_LOW)
-    public void onPlayerSpawnedEvent(OnPlayerSpawnedEvent event, EntityRef player) {
-        EntityRef toolbox = entityManager.create("StructureTemplates:toolbox");
-        inventoryManager.giveItem(player, EntityRef.NULL, toolbox);
-        Prefab prefab = assetManager.getAsset("AdventureAssets:bladeRoom", Prefab.class).get();
-        toolbox.send(new StructureSpawnerFromToolboxRequest(prefab));
-    }
-
     @ReceiveEvent(components = {SwingingBladeComponent.class, LocationComponent.class, BlockComponent.class})
     public void onSwingingBladeDestroyed(BeforeRemoveComponent event, EntityRef entity,
                                          SwingingBladeComponent swingingBladeComponent) {
@@ -99,6 +91,9 @@ public class SwingingBladeServerSystem extends BaseComponentSystem implements Up
         SwingingBladeComponent component = entity.getComponent(SwingingBladeComponent.class);
         swingingBladeComponent.childrenEntities = component.childrenEntities;
         entity.addOrSaveComponent(swingingBladeComponent);
+        LocationComponent locationComponent = entity.getComponent(LocationComponent.class);
+        locationComponent.setWorldRotation(swingingBladeComponent.rotation);
+        entity.addOrSaveComponent(locationComponent);
     }
 
     /**
@@ -114,6 +109,7 @@ public class SwingingBladeServerSystem extends BaseComponentSystem implements Up
             e.destroy();
         }
         swingingBladeComponent.childrenEntities = Lists.newArrayList();
+        swingingBladeComponent.rotation = blockEntity.getComponent(LocationComponent.class).getWorldRotation();
         event.getItem().addOrSaveComponent(swingingBladeComponent);
     }
 

--- a/src/main/java/org/terasology/adventureassets/traps/swingingblade/SwingingBladeSettingsScreen.java
+++ b/src/main/java/org/terasology/adventureassets/traps/swingingblade/SwingingBladeSettingsScreen.java
@@ -19,22 +19,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.systems.RegisterSystem;
-import org.terasology.input.cameraTarget.CameraTargetSystem;
-import org.terasology.logic.location.Location;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.geom.Quat4f;
-import org.terasology.protobuf.EntityData;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.BaseInteractionScreen;
-import org.terasology.rendering.nui.CoreScreenLayer;
 import org.terasology.rendering.nui.NUIManager;
 import org.terasology.rendering.nui.UIWidget;
-import org.terasology.rendering.nui.layouts.ColumnLayout;
-import org.terasology.rendering.nui.layouts.RowLayout;
-import org.terasology.rendering.nui.layouts.ScrollableArea;
 import org.terasology.rendering.nui.widgets.UIButton;
 import org.terasology.rendering.nui.widgets.UICheckbox;
-import org.terasology.rendering.nui.widgets.UILabel;
 import org.terasology.rendering.nui.widgets.UIText;
 
 /**
@@ -105,7 +97,7 @@ public class SwingingBladeSettingsScreen extends BaseInteractionScreen {
             double yawValue = Math.toRadians(Double.parseDouble(yaw.getText()));
             double pitchValue = Math.toRadians(Double.parseDouble(pitch.getText()));
             double rollValue = Math.toRadians(Double.parseDouble(roll.getText()));
-            locationComponent.setWorldRotation(new Quat4f((float) yawValue,(float) pitchValue,(float) rollValue));
+            locationComponent.setWorldRotation(new Quat4f((float) yawValue, (float) pitchValue, (float) rollValue));
         } catch (NumberFormatException e) {
             e.printStackTrace();
         }

--- a/src/main/java/org/terasology/adventureassets/traps/swingingblade/structuretemplateintegration/AddSwingingBladeComponent.java
+++ b/src/main/java/org/terasology/adventureassets/traps/swingingblade/structuretemplateintegration/AddSwingingBladeComponent.java
@@ -16,18 +16,16 @@
 package org.terasology.adventureassets.traps.swingingblade.structuretemplateintegration;
 
 import org.terasology.entitySystem.Component;
-import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.reflection.MappedContainer;
 import org.terasology.structureTemplates.events.SpawnStructureEvent;
-import org.terasology.world.block.family.BlockFamily;
 
 import java.util.List;
 
 /**
  * This component is intended to be used in structure templates.
- *
+ * <p>
  * It adds items (incl. block items) to one ore more chests when the entity receives a
  * {@link SpawnStructureEvent}.
  */

--- a/src/main/java/org/terasology/adventureassets/traps/swingingblade/structuretemplateintegration/SwingingBladeSTServerSystem.java
+++ b/src/main/java/org/terasology/adventureassets/traps/swingingblade/structuretemplateintegration/SwingingBladeSTServerSystem.java
@@ -27,7 +27,6 @@ import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.registry.In;
-import org.terasology.structureTemplates.components.AddItemsToChestComponent;
 import org.terasology.structureTemplates.components.ScheduleStructurePlacementComponent;
 import org.terasology.structureTemplates.events.BuildStructureTemplateEntityEvent;
 import org.terasology.structureTemplates.events.SpawnTemplateEvent;
@@ -54,7 +53,7 @@ public class SwingingBladeSTServerSystem extends BaseComponentSystem {
 
     @ReceiveEvent
     public void onSpawnStructure(StructureBlocksSpawnedEvent event, EntityRef entity,
-                                                  AddSwingingBladeComponent addSwingingBladeComponent) {
+                                 AddSwingingBladeComponent addSwingingBladeComponent) {
         configureSwingingBlades(addSwingingBladeComponent, event.getTransformation());
     }
 
@@ -68,6 +67,7 @@ public class SwingingBladeSTServerSystem extends BaseComponentSystem {
      * This method is called only after the OnActivatedComponent for the {@link SwingingBladeComponent} has executed.<br/>
      * Note: only the properties of the Swinging Blade should be overwritten in the {@link SwingingBladeComponent},
      * since the existing {@link SwingingBladeComponent} already has a list for childrenEntities (rod, blade and mesh).
+     *
      * @param addSwingingBladeComponent
      * @param transformation
      */
@@ -97,7 +97,7 @@ public class SwingingBladeSTServerSystem extends BaseComponentSystem {
 
         List<AddSwingingBladeComponent.SwingingBladesToSpawn> swingingBladesToSpawn = new ArrayList<>();
 
-        for (Vector3i position: event.findAbsolutePositionsOf(blockFamily)) {
+        for (Vector3i position : event.findAbsolutePositionsOf(blockFamily)) {
             EntityRef blockEntity = blockEntityRegistry.getBlockEntityAt(position);
             BlockComponent blockComponent = blockEntity.getComponent(BlockComponent.class);
             SwingingBladeComponent swingingBladeComponent = blockEntity.getComponent(SwingingBladeComponent.class);

--- a/src/main/java/org/terasology/adventureassets/traps/wipeout/WipeOutComponent.java
+++ b/src/main/java/org/terasology/adventureassets/traps/wipeout/WipeOutComponent.java
@@ -18,6 +18,7 @@ package org.terasology.adventureassets.traps.wipeout;
 import com.google.common.collect.Lists;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.math.geom.Quat4f;
 import org.terasology.world.block.ForceBlockActive;
 
 import java.util.List;
@@ -47,6 +48,11 @@ public class WipeOutComponent implements Component {
      * To set the wipe out motion direction (1: anticlockwise, -1:clockwise)
      */
     public int direction = 1;
+
+    /**
+     * Saved rotation extracted when block turns to item
+     */
+    public Quat4f rotation = new Quat4f(Quat4f.IDENTITY);
 
     public List<EntityRef> childrenEntities = Lists.newArrayList();
 }

--- a/src/main/java/org/terasology/adventureassets/traps/wipeout/WipeOutRotator.java
+++ b/src/main/java/org/terasology/adventureassets/traps/wipeout/WipeOutRotator.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.adventureassets.traps.wipeout;
+
+public interface WipeOutRotator {
+    public void updateWipeOutRotation();
+}

--- a/src/main/java/org/terasology/adventureassets/traps/wipeout/WipeOutServerSystem.java
+++ b/src/main/java/org/terasology/adventureassets/traps/wipeout/WipeOutServerSystem.java
@@ -18,36 +18,25 @@ package org.terasology.adventureassets.traps.wipeout;
 import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.adventureassets.traps.swingingblade.SwingingBladeClientSystem;
-import org.terasology.adventureassets.traps.swingingblade.SwingingBladeComponent;
 import org.terasology.assets.management.AssetManager;
 import org.terasology.engine.Time;
 import org.terasology.entitySystem.entity.EntityBuilder;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.entitySystem.entity.lifecycleEvents.BeforeRemoveComponent;
 import org.terasology.entitySystem.entity.lifecycleEvents.OnActivatedComponent;
-import org.terasology.entitySystem.event.EventPriority;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
-import org.terasology.logic.characters.CharacterComponent;
 import org.terasology.logic.inventory.InventoryManager;
-import org.terasology.logic.inventory.events.InventorySlotChangedEvent;
 import org.terasology.logic.location.Location;
 import org.terasology.logic.location.LocationComponent;
-import org.terasology.logic.players.event.OnPlayerSpawnedEvent;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.registry.In;
-import org.terasology.structureTemplates.events.StructureSpawnerFromToolboxRequest;
 import org.terasology.world.block.BlockComponent;
-import org.terasology.world.block.BlockManager;
-import org.terasology.world.block.family.BlockFamily;
 import org.terasology.world.block.items.BlockItemComponent;
 import org.terasology.world.block.items.OnBlockItemPlaced;
 import org.terasology.world.block.items.OnBlockToItem;
@@ -73,22 +62,27 @@ public class WipeOutServerSystem extends BaseComponentSystem implements UpdateSu
      * filtering the {@link WipeOutComponent} gets executed.
      * So the placedBlock entity already has the right childrenEntities and only needs the trap properties to be
      * transferred.
+     *
      * @param event
      * @param itemEntity
      * @param wipeOutComponent
      */
     @ReceiveEvent(components = {BlockItemComponent.class})
     public void onItemToBlock(OnBlockItemPlaced event, EntityRef itemEntity,
-                                  WipeOutComponent wipeOutComponent) {
+                              WipeOutComponent wipeOutComponent) {
         EntityRef entity = event.getPlacedBlock();
         WipeOutComponent component = entity.getComponent(WipeOutComponent.class);
         wipeOutComponent.childrenEntities = component.childrenEntities;
         entity.addOrSaveComponent(wipeOutComponent);
+        LocationComponent locationComponent = entity.getComponent(LocationComponent.class);
+        locationComponent.setWorldRotation(wipeOutComponent.rotation);
+        entity.addOrSaveComponent(locationComponent);
     }
 
     /**
      * This method transfers the stored properties in the block's {@link WipeOutComponent} to the new item created.
      * It also destroys the children entities, i.e. the rod, surfboard and the mesh.
+     *
      * @param event
      * @param blockEntity
      * @param wipeOutComponent
@@ -99,6 +93,7 @@ public class WipeOutServerSystem extends BaseComponentSystem implements UpdateSu
             e.destroy();
         }
         wipeOutComponent.childrenEntities = Lists.newArrayList();
+        wipeOutComponent.rotation = blockEntity.getComponent(LocationComponent.class).getWorldRotation();
         event.getItem().addOrSaveComponent(wipeOutComponent);
     }
 
@@ -110,13 +105,14 @@ public class WipeOutServerSystem extends BaseComponentSystem implements UpdateSu
      * {@link WipeOutServerSystem#onBlockToItem(OnBlockToItem, EntityRef, WipeOutComponent)} gets called.
      * So, the saved properties (offset, time-period etc) are transferred after this, maintaining
      * only the childrenEntities list created here.
+     *
      * @param event
      * @param entity
      * @param wipeOutComponent
      */
     @ReceiveEvent(components = {WipeOutComponent.class, BlockComponent.class})
     public void onWipeOutActivated(OnActivatedComponent event, EntityRef entity,
-                     WipeOutComponent wipeOutComponent) {
+                                   WipeOutComponent wipeOutComponent) {
         Prefab rodPrefab = assetManager.getAsset("AdventureAssets:wipeOutRod", Prefab.class).get();
         EntityBuilder rodEntityBuilder = entityManager.newBuilder(rodPrefab);
         rodEntityBuilder.setOwner(entity);
@@ -145,7 +141,7 @@ public class WipeOutServerSystem extends BaseComponentSystem implements UpdateSu
                 float t = time.getGameTime();
                 float timePeriod = wipeOutComponent.timePeriod;
                 float offset = wipeOutComponent.offset;
-                float angle = (float) (((t + offset) % timePeriod)*(2 * Math.PI / timePeriod))* wipeOutComponent.direction;
+                float angle = (float) (((t + offset) % timePeriod) * (2 * Math.PI / timePeriod)) * wipeOutComponent.direction;
                 Quat4f rotation = locationComponent.getLocalRotation();
                 locationComponent.setLocalRotation(new Quat4f(angle, rotation.getPitch(), rotation.getRoll()));
                 wipeOut.saveComponent(locationComponent);

--- a/src/main/java/org/terasology/adventureassets/traps/wipeout/WipeOutServerSystem.java
+++ b/src/main/java/org/terasology/adventureassets/traps/wipeout/WipeOutServerSystem.java
@@ -36,13 +36,15 @@ import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.registry.In;
+import org.terasology.registry.Share;
 import org.terasology.world.block.BlockComponent;
 import org.terasology.world.block.items.BlockItemComponent;
 import org.terasology.world.block.items.OnBlockItemPlaced;
 import org.terasology.world.block.items.OnBlockToItem;
 
+@Share(WipeOutRotator.class)
 @RegisterSystem(RegisterMode.AUTHORITY)
-public class WipeOutServerSystem extends BaseComponentSystem implements UpdateSubscriberSystem {
+public class WipeOutServerSystem extends BaseComponentSystem implements UpdateSubscriberSystem, WipeOutRotator {
 
     private static final Logger logger = LoggerFactory.getLogger(WipeOutServerSystem.class);
 
@@ -54,6 +56,8 @@ public class WipeOutServerSystem extends BaseComponentSystem implements UpdateSu
     private InventoryManager inventoryManager;
     @In
     private Time time;
+    @In
+    private WipeOutRotator wipeOutRotator;
 
     /**
      * This method transfers the saved block properties from the item to the block. <br/>
@@ -134,6 +138,11 @@ public class WipeOutServerSystem extends BaseComponentSystem implements UpdateSu
 
     @Override
     public void update(float delta) {
+        wipeOutRotator.updateWipeOutRotation();
+    }
+
+    @Override
+    public void updateWipeOutRotation() {
         for (EntityRef wipeOut : entityManager.getEntitiesWith(WipeOutComponent.class, BlockComponent.class)) {
             LocationComponent locationComponent = wipeOut.getComponent(LocationComponent.class);
             WipeOutComponent wipeOutComponent = wipeOut.getComponent(WipeOutComponent.class);

--- a/src/main/java/org/terasology/adventureassets/traps/wipeout/WipeOutSettingsScreen.java
+++ b/src/main/java/org/terasology/adventureassets/traps/wipeout/WipeOutSettingsScreen.java
@@ -17,7 +17,6 @@ package org.terasology.adventureassets.traps.wipeout;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.adventureassets.traps.swingingblade.SwingingBladeComponent;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.logic.location.LocationComponent;
@@ -100,7 +99,7 @@ public class WipeOutSettingsScreen extends BaseInteractionScreen {
             double yawValue = Math.toRadians(Double.parseDouble(yaw.getText()));
             double pitchValue = Math.toRadians(Double.parseDouble(pitch.getText()));
             double rollValue = Math.toRadians(Double.parseDouble(roll.getText()));
-            locationComponent.setWorldRotation(new Quat4f((float) yawValue,(float) pitchValue,(float) rollValue));
+            locationComponent.setWorldRotation(new Quat4f((float) yawValue, (float) pitchValue, (float) rollValue));
         } catch (NumberFormatException e) {
             e.printStackTrace();
         }

--- a/src/main/java/org/terasology/adventureassets/traps/wipeout/structuretemplateintegration/AddWipeOutComponent.java
+++ b/src/main/java/org/terasology/adventureassets/traps/wipeout/structuretemplateintegration/AddWipeOutComponent.java
@@ -26,7 +26,7 @@ import java.util.List;
 
 /**
  * This component is intended to be used in structure templates.
- *
+ * <p>
  * It adds items (incl. block items) to one ore more chests when the entity receives a
  * {@link SpawnStructureEvent}.
  */


### PR DESCRIPTION
Rotation changes are remembered after a block is mined and placed.

The duplicate code in the update method is now removed by using an interface.