### PR TITLE
Remember rotation after mining of trap blocks

### DIFF
--- a/assets/ui/FireballLauncherSettingsScreen.ui
+++ b/assets/ui/FireballLauncherSettingsScreen.ui
@@ -77,15 +77,6 @@
                   "type": "engine:UIText",
                   "id": "damageAmount",
                   "layoutInfo": {}
-                },
-                {
-                  "type": "UILabel",
-                  "text": "Health (Maximum collective damage)"
-                },
-                {
-                  "type": "engine:UIText",
-                  "id": "health",
-                  "layoutInfo": {}
                 }
               ]
             },

--- a/src/main/java/org/terasology/adventureassets/traps/fireballlauncher/FireballLauncherComponent.java
+++ b/src/main/java/org/terasology/adventureassets/traps/fireballlauncher/FireballLauncherComponent.java
@@ -15,13 +15,9 @@
  */
 package org.terasology.adventureassets.traps.fireballlauncher;
 
-import com.google.common.collect.Lists;
 import org.terasology.entitySystem.Component;
-import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.world.block.ForceBlockActive;
-
-import java.util.List;
 
 /**
  * This component holds the data for a Fireball Launcher

--- a/src/main/java/org/terasology/adventureassets/traps/fireballlauncher/FireballLauncherServerSystem.java
+++ b/src/main/java/org/terasology/adventureassets/traps/fireballlauncher/FireballLauncherServerSystem.java
@@ -30,7 +30,6 @@ import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
 import org.terasology.logic.health.HealthComponent;
 import org.terasology.logic.location.LocationComponent;
-import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.projectile.FireProjectileEvent;
 import org.terasology.projectile.ProjectileActionComponent;
@@ -104,7 +103,7 @@ public class FireballLauncherServerSystem extends BaseComponentSystem implements
                 Vector3f pos = fireballLauncher.getComponent(LocationComponent.class).getWorldPosition();
                 fireball.send(new FireProjectileEvent(pos, fireballLauncherComponent.direction));
 
-                fireballLauncherComponent.lastShotTime = (float) Math.floor(time.getGameTime()/fireballLauncherComponent.timePeriod)
+                fireballLauncherComponent.lastShotTime = (float) Math.floor(time.getGameTime() / fireballLauncherComponent.timePeriod)
                         * fireballLauncherComponent.timePeriod + fireballLauncherComponent.offset;
                 fireballLauncher.saveComponent(fireballLauncherComponent);
             }

--- a/src/main/java/org/terasology/adventureassets/traps/fireballlauncher/FireballLauncherSettingsScreen.java
+++ b/src/main/java/org/terasology/adventureassets/traps/fireballlauncher/FireballLauncherSettingsScreen.java
@@ -80,7 +80,7 @@ public class FireballLauncherSettingsScreen extends BaseInteractionScreen {
         timePeriod.setText("" + fireballLauncherComponent.timePeriod);
         offset.setText("" + fireballLauncherComponent.offset);
         maxDistance.setText("" + fireballLauncherComponent.maxDistance);
-        damageAmount.setText(""  + fireballLauncherComponent.damageAmount);
+        damageAmount.setText("" + fireballLauncherComponent.damageAmount);
         Vector3f direction = fireballLauncherComponent.direction;
 
         x.setText(String.format("%.2f", direction.getX()));

--- a/src/main/java/org/terasology/adventureassets/traps/fireballlauncher/structuretemplateintegration/AddFireballLauncherComponent.java
+++ b/src/main/java/org/terasology/adventureassets/traps/fireballlauncher/structuretemplateintegration/AddFireballLauncherComponent.java
@@ -26,7 +26,7 @@ import java.util.List;
 
 /**
  * This component is intended to be used in structure templates.
- *
+ * <p>
  * It adds items (incl. block items) to one ore more chests when the entity receives a
  * {@link SpawnStructureEvent}.
  */

--- a/src/main/java/org/terasology/adventureassets/traps/fireballlauncher/structuretemplateintegration/AddFireballLauncherComponent.java
+++ b/src/main/java/org/terasology/adventureassets/traps/fireballlauncher/structuretemplateintegration/AddFireballLauncherComponent.java
@@ -36,7 +36,6 @@ public class AddFireballLauncherComponent implements Component {
     @MappedContainer
     public static class FireballLauncherToSpawn {
         public Vector3i position;
-        public Quat4f rotation = new Quat4f(0, 0, 0, 1);
         public boolean isFiring;
         public float timePeriod;
         public float offset;

--- a/src/main/java/org/terasology/adventureassets/traps/fireballlauncher/structuretemplateintegration/FireballLauncherSTServerSystem.java
+++ b/src/main/java/org/terasology/adventureassets/traps/fireballlauncher/structuretemplateintegration/FireballLauncherSTServerSystem.java
@@ -18,18 +18,15 @@ package org.terasology.adventureassets.traps.fireballlauncher.structuretemplatei
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.adventureassets.traps.fireballlauncher.FireballLauncherComponent;
-import org.terasology.adventureassets.traps.swingingblade.SwingingBladeComponent;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.logic.location.LocationComponent;
-import org.terasology.math.Side;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.registry.In;
-import org.terasology.structureTemplates.components.ScheduleStructurePlacementComponent;
 import org.terasology.structureTemplates.events.BuildStructureTemplateEntityEvent;
 import org.terasology.structureTemplates.events.SpawnTemplateEvent;
 import org.terasology.structureTemplates.events.StructureBlocksSpawnedEvent;
@@ -55,7 +52,7 @@ public class FireballLauncherSTServerSystem extends BaseComponentSystem {
 
     @ReceiveEvent
     public void onSpawnStructure(StructureBlocksSpawnedEvent event, EntityRef entity,
-                                                  AddFireballLauncherComponent addFireballLauncherComponent) {
+                                 AddFireballLauncherComponent addFireballLauncherComponent) {
         configureFireballLaunchers(addFireballLauncherComponent, event.getTransformation());
     }
 
@@ -66,6 +63,7 @@ public class FireballLauncherSTServerSystem extends BaseComponentSystem {
 
     /**
      * This method is used to retrieve the stored settings for each Fireball Launcher once it is spawned.
+     *
      * @param addFireballLauncherComponent
      * @param transformation
      */
@@ -97,7 +95,7 @@ public class FireballLauncherSTServerSystem extends BaseComponentSystem {
 
         List<AddFireballLauncherComponent.FireballLauncherToSpawn> fireballLaunchersToSpawn = new ArrayList<>();
 
-        for (Vector3i position: event.findAbsolutePositionsOf(blockFamily)) {
+        for (Vector3i position : event.findAbsolutePositionsOf(blockFamily)) {
             EntityRef blockEntity = blockEntityRegistry.getBlockEntityAt(position);
             BlockComponent blockComponent = blockEntity.getComponent(BlockComponent.class);
             FireballLauncherComponent fireballLauncherComponent = blockEntity.getComponent(FireballLauncherComponent.class);

--- a/src/main/java/org/terasology/adventureassets/traps/swingingblade/SwingingBladeClientSystem.java
+++ b/src/main/java/org/terasology/adventureassets/traps/swingingblade/SwingingBladeClientSystem.java
@@ -22,29 +22,19 @@ import org.terasology.engine.Time;
 import org.terasology.entitySystem.entity.EntityBuilder;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.entitySystem.entity.lifecycleEvents.BeforeRemoveComponent;
 import org.terasology.entitySystem.entity.lifecycleEvents.OnActivatedComponent;
-import org.terasology.entitySystem.entity.lifecycleEvents.OnAddedComponent;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
-import org.terasology.logic.health.BeforeDamagedEvent;
-import org.terasology.logic.health.BeforeDestroyEvent;
-import org.terasology.logic.health.DestroyEvent;
-import org.terasology.logic.health.DoDestroyEvent;
 import org.terasology.logic.location.Location;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.registry.In;
-import org.terasology.world.BlockEntityRegistry;
 import org.terasology.world.block.BlockComponent;
-import org.terasology.world.block.entity.CreateBlockDropsEvent;
-import org.terasology.world.block.items.BlockItemComponent;
-import org.terasology.world.block.items.OnBlockItemPlaced;
 import org.terasology.world.block.items.OnBlockToItem;
 
 @RegisterSystem(RegisterMode.CLIENT)
@@ -68,6 +58,7 @@ public class SwingingBladeClientSystem extends BaseComponentSystem implements Up
      * {@link SwingingBladeServerSystem#onBlockToItem(OnBlockToItem, EntityRef, SwingingBladeComponent)} gets called.
      * So, the saved properties (amplitude, time-period, offset etc) are transferred after this, maintaining
      * only the childrenEntities list created here.
+     *
      * @param event
      * @param entity
      * @param swingingBladeComponent

--- a/src/main/java/org/terasology/adventureassets/traps/swingingblade/SwingingBladeComponent.java
+++ b/src/main/java/org/terasology/adventureassets/traps/swingingblade/SwingingBladeComponent.java
@@ -18,6 +18,7 @@ package org.terasology.adventureassets.traps.swingingblade;
 import com.google.common.collect.Lists;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.math.geom.Quat4f;
 import org.terasology.world.block.ForceBlockActive;
 
 import java.util.List;
@@ -47,6 +48,11 @@ public class SwingingBladeComponent implements Component {
      * To set the blade in motion, or stop it
      */
     public boolean isSwinging = true;
+
+    /**
+     * Saved rotation extracted when block turns to item
+     */
+    public Quat4f rotation = new Quat4f(Quat4f.IDENTITY);
 
     public List<EntityRef> childrenEntities = Lists.newArrayList();
 }

--- a/src/main/java/org/terasology/adventureassets/traps/swingingblade/SwingingBladeSettingsScreen.java
+++ b/src/main/java/org/terasology/adventureassets/traps/swingingblade/SwingingBladeSettingsScreen.java
@@ -19,22 +19,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.systems.RegisterSystem;
-import org.terasology.input.cameraTarget.CameraTargetSystem;
-import org.terasology.logic.location.Location;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.geom.Quat4f;
-import org.terasology.protobuf.EntityData;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.BaseInteractionScreen;
-import org.terasology.rendering.nui.CoreScreenLayer;
 import org.terasology.rendering.nui.NUIManager;
 import org.terasology.rendering.nui.UIWidget;
-import org.terasology.rendering.nui.layouts.ColumnLayout;
-import org.terasology.rendering.nui.layouts.RowLayout;
-import org.terasology.rendering.nui.layouts.ScrollableArea;
 import org.terasology.rendering.nui.widgets.UIButton;
 import org.terasology.rendering.nui.widgets.UICheckbox;
-import org.terasology.rendering.nui.widgets.UILabel;
 import org.terasology.rendering.nui.widgets.UIText;
 
 /**
@@ -105,7 +97,7 @@ public class SwingingBladeSettingsScreen extends BaseInteractionScreen {
             double yawValue = Math.toRadians(Double.parseDouble(yaw.getText()));
             double pitchValue = Math.toRadians(Double.parseDouble(pitch.getText()));
             double rollValue = Math.toRadians(Double.parseDouble(roll.getText()));
-            locationComponent.setWorldRotation(new Quat4f((float) yawValue,(float) pitchValue,(float) rollValue));
+            locationComponent.setWorldRotation(new Quat4f((float) yawValue, (float) pitchValue, (float) rollValue));
         } catch (NumberFormatException e) {
             e.printStackTrace();
         }

--- a/src/main/java/org/terasology/adventureassets/traps/swingingblade/structuretemplateintegration/AddSwingingBladeComponent.java
+++ b/src/main/java/org/terasology/adventureassets/traps/swingingblade/structuretemplateintegration/AddSwingingBladeComponent.java
@@ -16,18 +16,16 @@
 package org.terasology.adventureassets.traps.swingingblade.structuretemplateintegration;
 
 import org.terasology.entitySystem.Component;
-import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.reflection.MappedContainer;
 import org.terasology.structureTemplates.events.SpawnStructureEvent;
-import org.terasology.world.block.family.BlockFamily;
 
 import java.util.List;
 
 /**
  * This component is intended to be used in structure templates.
- *
+ * <p>
  * It adds items (incl. block items) to one ore more chests when the entity receives a
  * {@link SpawnStructureEvent}.
  */

--- a/src/main/java/org/terasology/adventureassets/traps/swingingblade/structuretemplateintegration/SwingingBladeSTServerSystem.java
+++ b/src/main/java/org/terasology/adventureassets/traps/swingingblade/structuretemplateintegration/SwingingBladeSTServerSystem.java
@@ -27,8 +27,6 @@ import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.registry.In;
-import org.terasology.structureTemplates.components.AddItemsToChestComponent;
-import org.terasology.structureTemplates.components.ScheduleStructurePlacementComponent;
 import org.terasology.structureTemplates.events.BuildStructureTemplateEntityEvent;
 import org.terasology.structureTemplates.events.SpawnTemplateEvent;
 import org.terasology.structureTemplates.events.StructureBlocksSpawnedEvent;
@@ -54,7 +52,7 @@ public class SwingingBladeSTServerSystem extends BaseComponentSystem {
 
     @ReceiveEvent
     public void onSpawnStructure(StructureBlocksSpawnedEvent event, EntityRef entity,
-                                                  AddSwingingBladeComponent addSwingingBladeComponent) {
+                                 AddSwingingBladeComponent addSwingingBladeComponent) {
         configureSwingingBlades(addSwingingBladeComponent, event.getTransformation());
     }
 
@@ -68,6 +66,7 @@ public class SwingingBladeSTServerSystem extends BaseComponentSystem {
      * This method is called only after the OnActivatedComponent for the {@link SwingingBladeComponent} has executed.<br/>
      * Note: only the properties of the Swinging Blade should be overwritten in the {@link SwingingBladeComponent},
      * since the existing {@link SwingingBladeComponent} already has a list for childrenEntities (rod, blade and mesh).
+     *
      * @param addSwingingBladeComponent
      * @param transformation
      */
@@ -97,7 +96,7 @@ public class SwingingBladeSTServerSystem extends BaseComponentSystem {
 
         List<AddSwingingBladeComponent.SwingingBladesToSpawn> swingingBladesToSpawn = new ArrayList<>();
 
-        for (Vector3i position: event.findAbsolutePositionsOf(blockFamily)) {
+        for (Vector3i position : event.findAbsolutePositionsOf(blockFamily)) {
             EntityRef blockEntity = blockEntityRegistry.getBlockEntityAt(position);
             BlockComponent blockComponent = blockEntity.getComponent(BlockComponent.class);
             SwingingBladeComponent swingingBladeComponent = blockEntity.getComponent(SwingingBladeComponent.class);

--- a/src/main/java/org/terasology/adventureassets/traps/wipeout/WipeOutClientSystem.java
+++ b/src/main/java/org/terasology/adventureassets/traps/wipeout/WipeOutClientSystem.java
@@ -17,8 +17,6 @@ package org.terasology.adventureassets.traps.wipeout;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.adventureassets.traps.swingingblade.SwingingBladeComponent;
-import org.terasology.adventureassets.traps.swingingblade.SwingingBladeServerSystem;
 import org.terasology.assets.management.AssetManager;
 import org.terasology.engine.Time;
 import org.terasology.entitySystem.entity.EntityBuilder;
@@ -60,13 +58,14 @@ public class WipeOutClientSystem extends BaseComponentSystem implements UpdateSu
      * {@link WipeOutServerSystem#onBlockToItem(OnBlockToItem, EntityRef, WipeOutComponent)} gets called.
      * So, the saved properties (amplitude, time-period, offset etc) are transferred after this, maintaining
      * only the childrenEntities list created here.
+     *
      * @param event
      * @param entity
      * @param wipeOutComponent
      */
     @ReceiveEvent(components = {WipeOutComponent.class, BlockComponent.class})
     public void onWipeOutActivated(OnActivatedComponent event, EntityRef entity,
-                                         WipeOutComponent wipeOutComponent) {
+                                   WipeOutComponent wipeOutComponent) {
         Prefab wipeOutPrefab = assetManager.getAsset("AdventureAssets:wipeOutMesh", Prefab.class).get();
         EntityBuilder wipeOutEntityBuilder = entityManager.newBuilder(wipeOutPrefab);
         wipeOutEntityBuilder.setOwner(entity);
@@ -86,7 +85,7 @@ public class WipeOutClientSystem extends BaseComponentSystem implements UpdateSu
                 float t = time.getGameTime();
                 float timePeriod = wipeOutComponent.timePeriod;
                 float offset = wipeOutComponent.offset;
-                float angle = (float) (((t + offset) % timePeriod)*(2 * Math.PI / timePeriod))* wipeOutComponent.direction;
+                float angle = (float) (((t + offset) % timePeriod) * (2 * Math.PI / timePeriod)) * wipeOutComponent.direction;
                 Quat4f rotation = locationComponent.getLocalRotation();
                 locationComponent.setLocalRotation(new Quat4f(angle, rotation.getPitch(), rotation.getRoll()));
                 wipeOut.saveComponent(locationComponent);

--- a/src/main/java/org/terasology/adventureassets/traps/wipeout/WipeOutComponent.java
+++ b/src/main/java/org/terasology/adventureassets/traps/wipeout/WipeOutComponent.java
@@ -18,6 +18,7 @@ package org.terasology.adventureassets.traps.wipeout;
 import com.google.common.collect.Lists;
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.math.geom.Quat4f;
 import org.terasology.world.block.ForceBlockActive;
 
 import java.util.List;
@@ -47,6 +48,11 @@ public class WipeOutComponent implements Component {
      * To set the wipe out motion direction (1: anticlockwise, -1:clockwise)
      */
     public int direction = 1;
+
+    /**
+     * Saved rotation extracted when block turns to item
+     */
+    public Quat4f rotation = new Quat4f(Quat4f.IDENTITY);
 
     public List<EntityRef> childrenEntities = Lists.newArrayList();
 }

--- a/src/main/java/org/terasology/adventureassets/traps/wipeout/WipeOutServerSystem.java
+++ b/src/main/java/org/terasology/adventureassets/traps/wipeout/WipeOutServerSystem.java
@@ -18,36 +18,25 @@ package org.terasology.adventureassets.traps.wipeout;
 import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.adventureassets.traps.swingingblade.SwingingBladeClientSystem;
-import org.terasology.adventureassets.traps.swingingblade.SwingingBladeComponent;
 import org.terasology.assets.management.AssetManager;
 import org.terasology.engine.Time;
 import org.terasology.entitySystem.entity.EntityBuilder;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.entitySystem.entity.lifecycleEvents.BeforeRemoveComponent;
 import org.terasology.entitySystem.entity.lifecycleEvents.OnActivatedComponent;
-import org.terasology.entitySystem.event.EventPriority;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
-import org.terasology.logic.characters.CharacterComponent;
 import org.terasology.logic.inventory.InventoryManager;
-import org.terasology.logic.inventory.events.InventorySlotChangedEvent;
 import org.terasology.logic.location.Location;
 import org.terasology.logic.location.LocationComponent;
-import org.terasology.logic.players.event.OnPlayerSpawnedEvent;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3f;
-import org.terasology.registry.CoreRegistry;
 import org.terasology.registry.In;
-import org.terasology.structureTemplates.events.StructureSpawnerFromToolboxRequest;
 import org.terasology.world.block.BlockComponent;
-import org.terasology.world.block.BlockManager;
-import org.terasology.world.block.family.BlockFamily;
 import org.terasology.world.block.items.BlockItemComponent;
 import org.terasology.world.block.items.OnBlockItemPlaced;
 import org.terasology.world.block.items.OnBlockToItem;
@@ -73,22 +62,27 @@ public class WipeOutServerSystem extends BaseComponentSystem implements UpdateSu
      * filtering the {@link WipeOutComponent} gets executed.
      * So the placedBlock entity already has the right childrenEntities and only needs the trap properties to be
      * transferred.
+     *
      * @param event
      * @param itemEntity
      * @param wipeOutComponent
      */
     @ReceiveEvent(components = {BlockItemComponent.class})
     public void onItemToBlock(OnBlockItemPlaced event, EntityRef itemEntity,
-                                  WipeOutComponent wipeOutComponent) {
+                              WipeOutComponent wipeOutComponent) {
         EntityRef entity = event.getPlacedBlock();
         WipeOutComponent component = entity.getComponent(WipeOutComponent.class);
         wipeOutComponent.childrenEntities = component.childrenEntities;
         entity.addOrSaveComponent(wipeOutComponent);
+        LocationComponent locationComponent = entity.getComponent(LocationComponent.class);
+        locationComponent.setWorldRotation(wipeOutComponent.rotation);
+        entity.addOrSaveComponent(locationComponent);
     }
 
     /**
      * This method transfers the stored properties in the block's {@link WipeOutComponent} to the new item created.
      * It also destroys the children entities, i.e. the rod, surfboard and the mesh.
+     *
      * @param event
      * @param blockEntity
      * @param wipeOutComponent
@@ -99,6 +93,7 @@ public class WipeOutServerSystem extends BaseComponentSystem implements UpdateSu
             e.destroy();
         }
         wipeOutComponent.childrenEntities = Lists.newArrayList();
+        wipeOutComponent.rotation = blockEntity.getComponent(LocationComponent.class).getWorldRotation();
         event.getItem().addOrSaveComponent(wipeOutComponent);
     }
 
@@ -110,13 +105,14 @@ public class WipeOutServerSystem extends BaseComponentSystem implements UpdateSu
      * {@link WipeOutServerSystem#onBlockToItem(OnBlockToItem, EntityRef, WipeOutComponent)} gets called.
      * So, the saved properties (offset, time-period etc) are transferred after this, maintaining
      * only the childrenEntities list created here.
+     *
      * @param event
      * @param entity
      * @param wipeOutComponent
      */
     @ReceiveEvent(components = {WipeOutComponent.class, BlockComponent.class})
     public void onWipeOutActivated(OnActivatedComponent event, EntityRef entity,
-                     WipeOutComponent wipeOutComponent) {
+                                   WipeOutComponent wipeOutComponent) {
         Prefab rodPrefab = assetManager.getAsset("AdventureAssets:wipeOutRod", Prefab.class).get();
         EntityBuilder rodEntityBuilder = entityManager.newBuilder(rodPrefab);
         rodEntityBuilder.setOwner(entity);
@@ -145,7 +141,7 @@ public class WipeOutServerSystem extends BaseComponentSystem implements UpdateSu
                 float t = time.getGameTime();
                 float timePeriod = wipeOutComponent.timePeriod;
                 float offset = wipeOutComponent.offset;
-                float angle = (float) (((t + offset) % timePeriod)*(2 * Math.PI / timePeriod))* wipeOutComponent.direction;
+                float angle = (float) (((t + offset) % timePeriod) * (2 * Math.PI / timePeriod)) * wipeOutComponent.direction;
                 Quat4f rotation = locationComponent.getLocalRotation();
                 locationComponent.setLocalRotation(new Quat4f(angle, rotation.getPitch(), rotation.getRoll()));
                 wipeOut.saveComponent(locationComponent);

--- a/src/main/java/org/terasology/adventureassets/traps/wipeout/WipeOutSettingsScreen.java
+++ b/src/main/java/org/terasology/adventureassets/traps/wipeout/WipeOutSettingsScreen.java
@@ -17,7 +17,6 @@ package org.terasology.adventureassets.traps.wipeout;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.adventureassets.traps.swingingblade.SwingingBladeComponent;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.logic.location.LocationComponent;
@@ -100,7 +99,7 @@ public class WipeOutSettingsScreen extends BaseInteractionScreen {
             double yawValue = Math.toRadians(Double.parseDouble(yaw.getText()));
             double pitchValue = Math.toRadians(Double.parseDouble(pitch.getText()));
             double rollValue = Math.toRadians(Double.parseDouble(roll.getText()));
-            locationComponent.setWorldRotation(new Quat4f((float) yawValue,(float) pitchValue,(float) rollValue));
+            locationComponent.setWorldRotation(new Quat4f((float) yawValue, (float) pitchValue, (float) rollValue));
         } catch (NumberFormatException e) {
             e.printStackTrace();
         }

--- a/src/main/java/org/terasology/adventureassets/traps/wipeout/structuretemplateintegration/AddWipeOutComponent.java
+++ b/src/main/java/org/terasology/adventureassets/traps/wipeout/structuretemplateintegration/AddWipeOutComponent.java
@@ -26,7 +26,7 @@ import java.util.List;
 
 /**
  * This component is intended to be used in structure templates.
- *
+ * <p>
  * It adds items (incl. block items) to one ore more chests when the entity receives a
  * {@link SpawnStructureEvent}.
  */

--- a/src/main/java/org/terasology/adventureassets/traps/wipeout/structuretemplateintegration/WipeOutSTServerSystem.java
+++ b/src/main/java/org/terasology/adventureassets/traps/wipeout/structuretemplateintegration/WipeOutSTServerSystem.java
@@ -17,7 +17,6 @@ package org.terasology.adventureassets.traps.wipeout.structuretemplateintegratio
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.adventureassets.traps.fireballlauncher.structuretemplateintegration.AddFireballLauncherComponent;
 import org.terasology.adventureassets.traps.wipeout.WipeOutComponent;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.ReceiveEvent;
@@ -28,7 +27,6 @@ import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.geom.Quat4f;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.registry.In;
-import org.terasology.structureTemplates.components.ScheduleStructurePlacementComponent;
 import org.terasology.structureTemplates.events.BuildStructureTemplateEntityEvent;
 import org.terasology.structureTemplates.events.SpawnTemplateEvent;
 import org.terasology.structureTemplates.events.StructureBlocksSpawnedEvent;


### PR DESCRIPTION
This PR consists changes that would make the trap block remember rotation changes after they are mined and placed again.

For the Fireball Launcher, there is a method that transforms the Vector3f direction to relative and absolute using the BlockRegionTransform Side.