### PR TITLE
Door works in multiplayer

### DIFF
--- a/src/main/java/org/terasology/adventureassets/traps/passwordDoor/OpenPasswordDoorRequest.java
+++ b/src/main/java/org/terasology/adventureassets/traps/passwordDoor/OpenPasswordDoorRequest.java
@@ -17,9 +17,11 @@ package org.terasology.adventureassets.traps.passwordDoor;
 
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.Event;
+import org.terasology.network.BroadcastEvent;
 import org.terasology.network.OwnerEvent;
+import org.terasology.network.ServerEvent;
 
-@OwnerEvent
+@BroadcastEvent
 public class OpenPasswordDoorRequest implements Event {
     private EntityRef doorEntity;
 

--- a/src/main/java/org/terasology/adventureassets/traps/passwordDoor/PasswordDoorClientSystem.java
+++ b/src/main/java/org/terasology/adventureassets/traps/passwordDoor/PasswordDoorClientSystem.java
@@ -41,7 +41,6 @@ public class PasswordDoorClientSystem extends BaseComponentSystem {
 
     @ReceiveEvent
     public void openPasswordDoorRequest(OpenPasswordDoorRequest event, EntityRef player) {
-        logger.info("open req");
         if (player.equals(localPlayer.getCharacterEntity())) {
             PasswordDoorScreen passwordDoorScreen = nuiManager.pushScreen("AdventureAssets:passwordDoorScreen", PasswordDoorScreen.class);
             passwordDoorScreen.setDoorEntity(event.getDoorEntity());

--- a/src/main/java/org/terasology/adventureassets/traps/passwordDoor/PasswordDoorClientSystem.java
+++ b/src/main/java/org/terasology/adventureassets/traps/passwordDoor/PasswordDoorClientSystem.java
@@ -16,8 +16,6 @@
 
 package org.terasology.adventureassets.traps.passwordDoor;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.terasology.core.logic.door.DoorPlacedEvent;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.ReceiveEvent;
@@ -28,11 +26,8 @@ import org.terasology.logic.players.LocalPlayer;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.NUIManager;
 
-/**
- */
 @RegisterSystem(RegisterMode.CLIENT)
 public class PasswordDoorClientSystem extends BaseComponentSystem {
-    private static final Logger logger = LoggerFactory.getLogger(PasswordDoorClientSystem.class);
 
     @In
     LocalPlayer localPlayer;

--- a/src/main/java/org/terasology/adventureassets/traps/passwordDoor/PasswordDoorComponent.java
+++ b/src/main/java/org/terasology/adventureassets/traps/passwordDoor/PasswordDoorComponent.java
@@ -18,9 +18,9 @@ package org.terasology.adventureassets.traps.passwordDoor;
 
 import org.terasology.entitySystem.Component;
 import org.terasology.network.Replicate;
+import org.terasology.world.block.ForceBlockActive;
 
-/**
- */
+@ForceBlockActive
 public class PasswordDoorComponent implements Component {
     @Replicate
     public String title = "title";

--- a/src/main/java/org/terasology/adventureassets/traps/passwordDoor/PasswordDoorComponent.java
+++ b/src/main/java/org/terasology/adventureassets/traps/passwordDoor/PasswordDoorComponent.java
@@ -16,15 +16,16 @@
 
 package org.terasology.adventureassets.traps.passwordDoor;
 
-import org.terasology.audio.StaticSound;
 import org.terasology.entitySystem.Component;
-import org.terasology.math.Side;
-import org.terasology.world.block.family.BlockFamily;
+import org.terasology.network.Replicate;
 
 /**
  */
 public class PasswordDoorComponent implements Component {
+    @Replicate
     public String title = "title";
+    @Replicate
     public String message = "message";
+    @Replicate
     public String password = "password";
 }

--- a/src/main/java/org/terasology/adventureassets/traps/passwordDoor/PasswordDoorScreen.java
+++ b/src/main/java/org/terasology/adventureassets/traps/passwordDoor/PasswordDoorScreen.java
@@ -15,9 +15,6 @@
  */
 package org.terasology.adventureassets.traps.passwordDoor;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.terasology.core.logic.door.OpenDoorEvent;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.players.LocalPlayer;
 import org.terasology.registry.In;
@@ -26,14 +23,8 @@ import org.terasology.rendering.nui.UIWidget;
 import org.terasology.rendering.nui.widgets.UIButton;
 import org.terasology.rendering.nui.widgets.UILabel;
 import org.terasology.rendering.nui.widgets.UIText;
-import org.terasology.world.BlockEntityRegistry;
-import org.terasology.world.WorldProvider;
-
-/**
- */
 
 public class PasswordDoorScreen extends CoreScreenLayer {
-    private static final Logger logger = LoggerFactory.getLogger(PasswordDoorScreen.class);
 
     private UILabel title;
     private UILabel message;
@@ -45,10 +36,6 @@ public class PasswordDoorScreen extends CoreScreenLayer {
     private PasswordDoorComponent passwordDoorComponent;
     private String passwordString;
 
-    @In
-    private WorldProvider worldProvider;
-    @In
-    private BlockEntityRegistry blockEntityRegistry;
     @In
     private LocalPlayer localPlayer;
 
@@ -78,8 +65,6 @@ public class PasswordDoorScreen extends CoreScreenLayer {
     private void onUnlockButton(UIWidget button) {
         String enteredPassword = password.getText();
         if (enteredPassword.equalsIgnoreCase(passwordString)) {
-            logger.info("sending open door event");
-            localPlayer.getClientEntity().send(new OpenDoorEvent(doorEntity));
             getManager().popScreen();
         } else {
             invalid.setVisible(true);

--- a/src/main/java/org/terasology/adventureassets/traps/passwordDoor/PasswordDoorScreen.java
+++ b/src/main/java/org/terasology/adventureassets/traps/passwordDoor/PasswordDoorScreen.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.adventureassets.traps.passwordDoor;
 
+import org.terasology.core.logic.door.OpenDoorEvent;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.players.LocalPlayer;
 import org.terasology.registry.In;
@@ -65,6 +66,7 @@ public class PasswordDoorScreen extends CoreScreenLayer {
     private void onUnlockButton(UIWidget button) {
         String enteredPassword = password.getText();
         if (enteredPassword.equalsIgnoreCase(passwordString)) {
+            localPlayer.getClientEntity().send(new OpenDoorEvent(doorEntity));
             getManager().popScreen();
         } else {
             invalid.setVisible(true);

--- a/src/main/java/org/terasology/adventureassets/traps/passwordDoor/PasswordDoorScreen.java
+++ b/src/main/java/org/terasology/adventureassets/traps/passwordDoor/PasswordDoorScreen.java
@@ -66,7 +66,7 @@ public class PasswordDoorScreen extends CoreScreenLayer {
     private void onUnlockButton(UIWidget button) {
         String enteredPassword = password.getText();
         if (enteredPassword.equalsIgnoreCase(passwordString)) {
-            localPlayer.getClientEntity().send(new OpenDoorEvent(doorEntity));
+            localPlayer.getCharacterEntity().send(new OpenDoorEvent(doorEntity));
             getManager().popScreen();
         } else {
             invalid.setVisible(true);

--- a/src/main/java/org/terasology/adventureassets/traps/passwordDoor/PasswordDoorServerSystem.java
+++ b/src/main/java/org/terasology/adventureassets/traps/passwordDoor/PasswordDoorServerSystem.java
@@ -18,12 +18,10 @@ package org.terasology.adventureassets.traps.passwordDoor;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.audio.events.PlaySoundEvent;
 import org.terasology.core.logic.door.CloseDoorEvent;
 import org.terasology.core.logic.door.DoorComponent;
 import org.terasology.core.logic.door.OpenDoorEvent;
 import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.entitySystem.entity.lifecycleEvents.OnActivatedComponent;
 import org.terasology.entitySystem.event.EventPriority;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
@@ -31,12 +29,10 @@ import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.logic.common.ActivateEvent;
 import org.terasology.logic.location.LocationComponent;
-import org.terasology.math.Side;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.NUIManager;
 import org.terasology.world.BlockEntityRegistry;
 import org.terasology.world.WorldProvider;
-import org.terasology.world.block.Block;
 import org.terasology.world.block.regions.BlockRegionComponent;
 
 /**
@@ -62,10 +58,5 @@ public class PasswordDoorServerSystem extends BaseComponentSystem {
         } else {
             event.getInstigator().send(new OpenPasswordDoorRequest(entity));
         }
-    }
-
-    @ReceiveEvent
-    public void openDoor(OpenDoorEvent event, EntityRef player) {
-        logger.info("opennn");
     }
 }

--- a/src/main/java/org/terasology/adventureassets/traps/passwordDoor/PasswordDoorServerSystem.java
+++ b/src/main/java/org/terasology/adventureassets/traps/passwordDoor/PasswordDoorServerSystem.java
@@ -16,11 +16,8 @@
 
 package org.terasology.adventureassets.traps.passwordDoor;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.terasology.core.logic.door.CloseDoorEvent;
 import org.terasology.core.logic.door.DoorComponent;
-import org.terasology.core.logic.door.OpenDoorEvent;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.EventPriority;
 import org.terasology.entitySystem.event.ReceiveEvent;
@@ -35,11 +32,8 @@ import org.terasology.world.BlockEntityRegistry;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.block.regions.BlockRegionComponent;
 
-/**
- */
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class PasswordDoorServerSystem extends BaseComponentSystem {
-    private static final Logger logger = LoggerFactory.getLogger(PasswordDoorServerSystem.class);
 
     @In
     private WorldProvider worldProvider;
@@ -58,5 +52,15 @@ public class PasswordDoorServerSystem extends BaseComponentSystem {
         } else {
             event.getInstigator().send(new OpenPasswordDoorRequest(entity));
         }
+    }
+
+    @ReceiveEvent
+    public void setPasswordDoor(SetPasswordDoorEvent event, EntityRef entity) {
+        EntityRef doorEntity = event.getDoorEntity();
+        PasswordDoorComponent passwordDoorComponent = new PasswordDoorComponent();
+        passwordDoorComponent.title = event.getTitle();
+        passwordDoorComponent.message = event.getMessage();
+        passwordDoorComponent.password = event.getPassword();
+        doorEntity.addOrSaveComponent(passwordDoorComponent);
     }
 }

--- a/src/main/java/org/terasology/adventureassets/traps/passwordDoor/SetPasswordDoorEvent.java
+++ b/src/main/java/org/terasology/adventureassets/traps/passwordDoor/SetPasswordDoorEvent.java
@@ -17,18 +17,35 @@ package org.terasology.adventureassets.traps.passwordDoor;
 
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.Event;
-import org.terasology.network.OwnerEvent;
+import org.terasology.network.ServerEvent;
 
-@OwnerEvent
-public class OpenPasswordDoorRequest implements Event {
+@ServerEvent
+public class SetPasswordDoorEvent implements Event {
     private EntityRef doorEntity;
+    private String title;
+    private String message;
+    private String password;
 
-    public OpenPasswordDoorRequest() {
-        doorEntity = EntityRef.NULL;
+    public SetPasswordDoorEvent() {
     }
 
-    public OpenPasswordDoorRequest(EntityRef doorEntity) {
+    public SetPasswordDoorEvent(EntityRef doorEntity, String title, String message, String password) {
+        this.title = title;
+        this.message = message;
+        this.password = password;
         this.doorEntity = doorEntity;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getPassword() {
+        return password;
     }
 
     public EntityRef getDoorEntity() {

--- a/src/main/java/org/terasology/adventureassets/traps/passwordDoor/SetPasswordDoorScreen.java
+++ b/src/main/java/org/terasology/adventureassets/traps/passwordDoor/SetPasswordDoorScreen.java
@@ -25,9 +25,6 @@ import org.terasology.rendering.nui.widgets.UIButton;
 import org.terasology.rendering.nui.widgets.UILabel;
 import org.terasology.rendering.nui.widgets.UIText;
 
-/**
- */
-@RegisterSystem
 public class SetPasswordDoorScreen extends CoreScreenLayer {
     private static final Logger logger = LoggerFactory.getLogger(SetPasswordDoorScreen.class);
 
@@ -68,6 +65,7 @@ public class SetPasswordDoorScreen extends CoreScreenLayer {
             passwordDoorComponent.message = message.getText();
             passwordDoorComponent.password = password.getText();
             doorEntity.saveComponent(passwordDoorComponent);
+            logger.info(doorEntity.toFullDescription());
             getManager().popScreen();
         } else {
             invalid.setVisible(true);

--- a/src/main/java/org/terasology/adventureassets/traps/passwordDoor/SetPasswordDoorScreen.java
+++ b/src/main/java/org/terasology/adventureassets/traps/passwordDoor/SetPasswordDoorScreen.java
@@ -60,7 +60,7 @@ public class SetPasswordDoorScreen extends CoreScreenLayer {
 
     private void onSaveButton(UIWidget button) {
         if (password.getText().length() > 0 && title.getText().length() > 0 && message.getText().length() > 0) {
-            localPlayer.getCharacterEntity().send(new SetPasswordDoorEvent(doorEntity, title.getText(), message.getText(), password.getText()));
+            localPlayer.getClientEntity().send(new SetPasswordDoorEvent(doorEntity, title.getText(), message.getText(), password.getText()));
             getManager().popScreen();
         } else {
             invalid.setVisible(true);

--- a/src/main/java/org/terasology/adventureassets/traps/passwordDoor/SetPasswordDoorScreen.java
+++ b/src/main/java/org/terasology/adventureassets/traps/passwordDoor/SetPasswordDoorScreen.java
@@ -18,7 +18,8 @@ package org.terasology.adventureassets.traps.passwordDoor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.logic.players.LocalPlayer;
+import org.terasology.registry.In;
 import org.terasology.rendering.nui.CoreScreenLayer;
 import org.terasology.rendering.nui.UIWidget;
 import org.terasology.rendering.nui.widgets.UIButton;
@@ -27,15 +28,14 @@ import org.terasology.rendering.nui.widgets.UIText;
 
 public class SetPasswordDoorScreen extends CoreScreenLayer {
     private static final Logger logger = LoggerFactory.getLogger(SetPasswordDoorScreen.class);
-
+    @In
+    LocalPlayer localPlayer;
     private UIText title;
     private UIText message;
     private UIText password;
     private UILabel invalid;
     private UIButton saveButton;
-
     private EntityRef doorEntity;
-    private PasswordDoorComponent passwordDoorComponent;
 
     @Override
     public void initialise() {
@@ -52,7 +52,6 @@ public class SetPasswordDoorScreen extends CoreScreenLayer {
 
     void setDoorEntity(EntityRef door) {
         doorEntity = door;
-        passwordDoorComponent = doorEntity.getComponent(PasswordDoorComponent.class);
         title.setText("");
         message.setText("");
         password.setText("");
@@ -61,11 +60,7 @@ public class SetPasswordDoorScreen extends CoreScreenLayer {
 
     private void onSaveButton(UIWidget button) {
         if (password.getText().length() > 0 && title.getText().length() > 0 && message.getText().length() > 0) {
-            passwordDoorComponent.title = title.getText();
-            passwordDoorComponent.message = message.getText();
-            passwordDoorComponent.password = password.getText();
-            doorEntity.saveComponent(passwordDoorComponent);
-            logger.info(doorEntity.toFullDescription());
+            localPlayer.getCharacterEntity().send(new SetPasswordDoorEvent(doorEntity, title.getText(), message.getText(), password.getText()));
             getManager().popScreen();
         } else {
             invalid.setVisible(true);


### PR DESCRIPTION
This fix goes an extra step which might not be necessary. The Settings Screen that opens only on the client is used to save the PasswordDoorComponent on the door entity. However, saving the component from the Settings Screen class saves the component only to the client entity. The server entity remains unaffected.

The current solution I implemented sends a event from the settings screen class. This event is received on the server system and the change is then made to the server entity directly. The `@Replicate` works from Server to Client as expected.

### To Test:
- Create headless + client 1 + client 2 instances
- Do a `give paswordDoor` for client 1. Also do a `give sand`.
- Create a sand wall two blocks tall. Place the door next to the sand wall.
- Placing a door creates a settings screen. Fill in the details for the password door.
- Check if the door is accessible with the same details for client 2.