### PR TITLE
Fixed Fireball Launcher for multiplayer

### DIFF
--- a/src/main/java/org/terasology/adventureassets/traps/fireballlauncher/FireballLauncherComponent.java
+++ b/src/main/java/org/terasology/adventureassets/traps/fireballlauncher/FireballLauncherComponent.java
@@ -17,6 +17,7 @@ package org.terasology.adventureassets.traps.fireballlauncher;
 
 import org.terasology.entitySystem.Component;
 import org.terasology.math.geom.Vector3f;
+import org.terasology.network.Replicate;
 import org.terasology.world.block.ForceBlockActive;
 
 /**
@@ -29,36 +30,43 @@ public class FireballLauncherComponent implements Component {
     /**
      * Sets the fireball launcher as active or inactive
      */
+    @Replicate
     public boolean isFiring = true;
 
     /**
      * Time between two strikes
      */
+    @Replicate
     public float timePeriod = 2f;
 
     /**
      * Time offset for synchronization of multiple launchers
      * Two launchers having the same time period can operate at offsets to fire at different instances
      */
+    @Replicate
     public float offset = 0f;
 
     /**
      * Last shot time
      */
+    @Replicate
     public float lastShotTime = 0f;
 
     /**
      * Direction to fire
      */
+    @Replicate
     public Vector3f direction = Vector3f.north();
 
     /**
      * Distance till which fireball lasts
      */
+    @Replicate
     public int maxDistance = 24;
 
     /**
      * Total collective damage that can be inflicted
      */
+    @Replicate
     public int damageAmount = 20;
 }

--- a/src/main/java/org/terasology/adventureassets/traps/fireballlauncher/FireballLauncherServerSystem.java
+++ b/src/main/java/org/terasology/adventureassets/traps/fireballlauncher/FireballLauncherServerSystem.java
@@ -78,6 +78,27 @@ public class FireballLauncherServerSystem extends BaseComponentSystem implements
     }
 
     /**
+     * Saves the settings to the server FireballLauncherRoot entity once the Ok button is clicked on the settings screen.
+     * All changes are then replicated to the client entities.
+     *
+     * @param event
+     * @param player
+     */
+    @ReceiveEvent
+    public void setFireballLauncher(SetFireballLauncherEvent event, EntityRef player) {
+        EntityRef fireballLauncherRoot = event.getFireballLauncherRoot();
+        FireballLauncherComponent fireballLauncherComponent = fireballLauncherRoot.getComponent(FireballLauncherComponent.class);
+        fireballLauncherComponent.isFiring = event.isFiring();
+        fireballLauncherComponent.timePeriod = event.getTimePeriod();
+        fireballLauncherComponent.damageAmount = event.getDamageAmount();
+        fireballLauncherComponent.maxDistance = event.getMaxDistance();
+        fireballLauncherComponent.offset = event.getOffset();
+        fireballLauncherComponent.direction = event.getDirection();
+
+        fireballLauncherRoot.saveComponent(fireballLauncherComponent);
+    }
+
+    /**
      * Find all Fireball Launchers and trigger the launch of a Fireball if it is the right time
      *
      * @param delta The time (in seconds) since the last engine update.

--- a/src/main/java/org/terasology/adventureassets/traps/fireballlauncher/FireballLauncherSettingsScreen.java
+++ b/src/main/java/org/terasology/adventureassets/traps/fireballlauncher/FireballLauncherSettingsScreen.java
@@ -18,7 +18,7 @@ package org.terasology.adventureassets.traps.fireballlauncher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.logic.players.LocalPlayer;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.BaseInteractionScreen;
@@ -28,9 +28,6 @@ import org.terasology.rendering.nui.widgets.UIButton;
 import org.terasology.rendering.nui.widgets.UICheckbox;
 import org.terasology.rendering.nui.widgets.UIText;
 
-/**
- */
-@RegisterSystem
 public class FireballLauncherSettingsScreen extends BaseInteractionScreen {
     private static final Logger logger = LoggerFactory.getLogger(FireballLauncherSettingsScreen.class);
 
@@ -49,6 +46,8 @@ public class FireballLauncherSettingsScreen extends BaseInteractionScreen {
 
     @In
     private NUIManager nuiManager;
+    @In
+    private LocalPlayer localPlayer;
 
     @Override
     public void initialise() {
@@ -100,10 +99,13 @@ public class FireballLauncherSettingsScreen extends BaseInteractionScreen {
             double zValue = Double.parseDouble(z.getText());
             fireballLauncherComponent.direction = new Vector3f((float) xValue, (float) yValue, (float) zValue);
             fireballLauncherComponent.direction.normalize();
+            localPlayer.getCharacterEntity().send(new SetFireballLauncherEvent(fireballLauncherRoot,
+                    fireballLauncherComponent.isFiring, fireballLauncherComponent.timePeriod,
+                    fireballLauncherComponent.offset, fireballLauncherComponent.direction,
+                    fireballLauncherComponent.maxDistance, fireballLauncherComponent.damageAmount));
         } catch (NumberFormatException e) {
             e.printStackTrace();
         }
-        fireballLauncherRoot.saveComponent(fireballLauncherComponent);
         getManager().popScreen();
     }
 

--- a/src/main/java/org/terasology/adventureassets/traps/fireballlauncher/SetFireballLauncherEvent.java
+++ b/src/main/java/org/terasology/adventureassets/traps/fireballlauncher/SetFireballLauncherEvent.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.adventureassets.traps.fireballlauncher;
+
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.Event;
+import org.terasology.math.geom.Vector3f;
+import org.terasology.network.ServerEvent;
+
+@ServerEvent
+public class SetFireballLauncherEvent implements Event {
+    private EntityRef fireballLauncherRoot;
+    private boolean isFiring = true;
+    private float timePeriod = 2f;
+    private float offset = 0f;
+    private Vector3f direction = Vector3f.north();
+    private int maxDistance = 24;
+    private int damageAmount = 20;
+
+    public SetFireballLauncherEvent() {
+        fireballLauncherRoot = EntityRef.NULL;
+    }
+
+    public SetFireballLauncherEvent(EntityRef doorEntity, boolean isFiring, float timePeriod, float offset, Vector3f direction, int maxDistance, int damageAmount) {
+        this.fireballLauncherRoot = doorEntity;
+        this.isFiring = isFiring;
+        this.timePeriod = timePeriod;
+        this.offset = offset;
+        this.direction = direction;
+        this.maxDistance = maxDistance;
+        this.damageAmount = damageAmount;
+    }
+
+    public EntityRef getFireballLauncherRoot() {
+        return fireballLauncherRoot;
+    }
+
+    public boolean isFiring() {
+        return isFiring;
+    }
+
+    public float getTimePeriod() {
+        return timePeriod;
+    }
+
+    public float getOffset() {
+        return offset;
+    }
+
+    public Vector3f getDirection() {
+        return direction;
+    }
+
+    public int getDamageAmount() {
+        return damageAmount;
+    }
+
+    public int getMaxDistance() {
+        return maxDistance;
+    }
+}


### PR DESCRIPTION
This fixes the Fireball Launcher to work in the multiplayer mode.
The approach taken is similar to the Password Door, a `SetFireballLauncherEvent` is sent from the Screen class and received at the Authority system that deals with saving the component on the server FireballLauncherRoot entity. All changes are then replicated to the client entities.

### To test:
- Create headless + client 1 + client 2 instances
- Do a `give fireballLauncherRoot` on client 1 and place it in the world
- Make changes to the settings for the fireball launcher by interacting with it using `E`
- Check if changes made by one client are visible to the other