### PR TITLE
fix: Use character location as respawn position

### DIFF
--- a/src/main/java/org/terasology/adventureassets/altarofresurrection/ResurrectionServerSystem.java
+++ b/src/main/java/org/terasology/adventureassets/altarofresurrection/ResurrectionServerSystem.java
@@ -57,13 +57,15 @@ public class ResurrectionServerSystem extends BaseComponentSystem {
      */
     @ReceiveEvent(priority = EventPriority.PRIORITY_HIGH, components = {ClientComponent.class})
     public void setSpawnLocationOnRespawnRequest(RespawnRequestEvent event, EntityRef entity) {
-        EntityRef clientInfo = entity.getComponent(ClientComponent.class).clientInfo;
+        ClientComponent clientComponent = entity.getComponent(ClientComponent.class);
+        EntityRef character = clientComponent.character;
+        EntityRef clientInfo = clientComponent.clientInfo;
         if (clientInfo.hasComponent(RevivePlayerComponent.class)) {
             Vector3f spawnPosition = clientInfo.getComponent(RevivePlayerComponent.class).location;
-            LocationComponent loc = entity.getComponent(LocationComponent.class);
+            LocationComponent loc = character.getComponent(LocationComponent.class);
             loc.setWorldPosition(spawnPosition);
             loc.setLocalRotation(new Quat4f());
-            entity.saveComponent(loc);
+            character.saveComponent(loc);
         }
     }
 


### PR DESCRIPTION
Altar of Resurrection now spawns the player at the location of last activated Altar i.e. it works as intended.